### PR TITLE
Multi ghc - and dependencies tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,82 @@
-env:
-  - CABALVER=1.18 GHCVER=7.8.4
-  - CABALVER=1.22 GHCVER=7.10.1
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
 
-# Note: the distinction between `before_install` and `install` is not important.
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      compiler: ": #GHC 7.10.2"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+
 before_install:
-  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
-  - travis_retry sudo apt-get update
-  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
-  - travis_retry sudo apt-get install libpcre3 libpcre3-dev
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
-  - cabal --version
-  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-  - travis_retry cabal update
-  - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+ 
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
 script:
-  - if [ -f configure.ac ]; then autoreconf -i; fi
-  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
-  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
-  - cabal test
-  - cabal check
-  - cabal sdist   # tests that a source-distribution can be generated
-  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-    (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
 
-after_script:
-  - cat dist/test/aeson-schema-*-tests.log
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/aeson-schema.cabal
+++ b/aeson-schema.cabal
@@ -35,7 +35,7 @@ library
                        Data.Aeson.TH.Lift
   extensions:          OverloadedStrings
   build-depends:       base > 4 && < 5,
-                       aeson >= 0.8.0.0 && < 0.10,
+                       aeson >= 0.7.0.0 && < 0.11,
                        vector >= 0.10 && < 0.12,
                        text >= 1.2 && < 1.3,
                        regex-pcre >= 0.94.4 && < 0.95,
@@ -47,7 +47,7 @@ library
                        mtl >= 2 && < 3,
                        transformers >= 0.3.0.0 && < 0.5,
                        QuickCheck >= 2.4.2 && < 2.9,
-                       syb >= 0.4.4 && < 0.6,
+                       syb >= 0.4.4 && < 0.7,
                        bytestring >= 0.9.2.1 && < 0.11,
                        scientific >= 0.3.3.7 && < 0.4,
                        ghc-prim,

--- a/aeson-schema.cabal
+++ b/aeson-schema.cabal
@@ -12,6 +12,7 @@ copyright:           (c) 2012-2015 Tim Baumann
 category:            Data
 build-type:          Simple
 cabal-version:       >= 1.8
+tested-with:         GHC==7.6.3, GHC==7.8.4, GHC==7.10.2
 extra-source-files:  CHANGELOG.md
 data-files:          test/test-suite/tests/draft3/optional/*.json,
                      test/test-suite/tests/draft3/*.json

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: nightly-2015-07-21
+resolver: lts-3.13


### PR DESCRIPTION
Related: https://github.com/fpco/stackage/issues/856

- aeson-0.7 allows tests to build with ghc 7.6; aeson-0.8 requires newer bytestring, but test depend on `ghc` thru `hint`.