### PR TITLE
template-haskell-2.11.0.0 compatibility

### DIFF
--- a/aeson-schema.cabal
+++ b/aeson-schema.cabal
@@ -50,6 +50,7 @@ library
                        syb >= 0.4.4 && < 0.7,
                        bytestring >= 0.9.2.1 && < 0.11,
                        scientific >= 0.3.3.7 && < 0.4,
+                       fail == 4.9.0.0,
                        ghc-prim,
                        regex-compat,
                        regex-base

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,1 @@
-flags: {}
-packages:
-- '.'
-extra-deps: []
-resolver: lts-3.13
+resolver: lts-7.4


### PR DESCRIPTION
This patch adds `template-haskell-2.11.0.0` compatibility. I'm not sure it's totally done yet, as the test suite is failing with:

```
WARNING: filepath wildcard 'test/test-suite/tests/draft3/optional/*.json' does not match any files.
WARNING: filepath wildcard 'test/test-suite/tests/draft3/*.json' does not match any files.
aeson-schema-0.4.1.1: copy/register
test/test-suite/tests/draft3/optional/: getDirectoryContents: does not exist
(No such file or directory)
'cabal copy' failed.  Error message:

--  While building package aeson-schema-0.4.1.1 using:
      /home/mitchell/.stack/setup-exe-cache/x86_64-linux/setup-Simple-Cabal-1.24.0.0-ghc-8.0.1 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.24.0.0 copy
    Process exited with code: ExitFailure 1

One possible cause of this issue is:
* No module named "Main". The 'main-is' source file should usually have a header indicating that it's a 'Main' module.
```

Any tips on getting it to work?
